### PR TITLE
fix(node): min version required by pdf.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,6 @@
     "vite-tsconfig-paths": "^5.0.1"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   }
 }


### PR DESCRIPTION
Hi there, nice work so far!

Just a small PR for upping the min version of node required to start the dev script.

Briefly: PDF.js is requiring Node 22

Reference: https://stackoverflow.com/questions/78415681/pdf-js-pdfjs-dist-promise-withresolvers-is-not-a-function