### PR TITLE
refactor(config): consolidated modelConfig under an unique interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,18 +61,21 @@ This will launch the platform, and you will be able to interact with it in your 
 `POST /api/execute` endpoint executes pipeline using given LLM provider and model.  
 The body should be a JSON object with the following fields:
 
-- **provider**: The language model provider you wish to use.
-- **model** (`LLMModel`): The specific model to use, based on the selected provider.
-- **key** (`string`): The API key to authenticate with the specified provider.
+- **modelConfig** (`ModelConfig`): Configuration of the model you wish to use, as follows:
+  - **provider**: The language model provider you wish to use.
+  - **model** (`LLMModel`): The specific model to use, based on the selected provider.
+  - **key** (`string`): The API key to authenticate with the specified provider.
 - **pipeline** (`Pipeline`): The configuration for the processing pipeline.
 
 Example request:
 
 ```json
 {
-  "provider": "openai",
-  "model": "gpt-4o-mini",
-  "key": "sk-your-api-key",
+  "modelConfig": {
+    "provider": "openai",
+    "model": "gpt-4o-mini",
+    "key": "sk-your-api-key"
+  },
   "pipeline": {
     // your pipeline configuration
   }

--- a/app/components/pipeline/nodes/OutputNode.tsx
+++ b/app/components/pipeline/nodes/OutputNode.tsx
@@ -80,13 +80,13 @@ export function OutputNode() {
     const prompt = promptTokens.reduce((acc, val) => acc + val, 0);
     const completion = completionTokens.reduce((acc, val) => acc + val, 0);
     const inputCost =
-      litlyticsConfig.provider === 'ollama'
+      litlyticsConfig.modelConfig.provider === 'ollama'
         ? 0
-        : modelCosts[litlyticsConfig.model].input;
+        : modelCosts[litlyticsConfig.modelConfig.model].input;
     const outputCost =
-      litlyticsConfig.provider === 'ollama'
+      litlyticsConfig.modelConfig.provider === 'ollama'
         ? 0
-        : modelCosts[litlyticsConfig.model].output;
+        : modelCosts[litlyticsConfig.modelConfig.model].output;
     const cost = _.round(prompt * inputCost + completion * outputCost, 3);
     return { timing, prompt, completion, cost };
   }, [output, litlyticsConfig]);

--- a/app/components/pipeline/nodes/StepNode.tsx
+++ b/app/components/pipeline/nodes/StepNode.tsx
@@ -91,13 +91,13 @@ export function StepNode({ data }: { data: ProcessingStep }) {
           completionTokens.length
       );
       const inputCost =
-        litlyticsConfig.provider === 'ollama'
+        litlyticsConfig.modelConfig.provider === 'ollama'
           ? 0
-          : modelCosts[litlyticsConfig.model].input;
+          : modelCosts[litlyticsConfig.modelConfig.model].input;
       const outputCost =
-        litlyticsConfig.provider === 'ollama'
+        litlyticsConfig.modelConfig.provider === 'ollama'
           ? 0
-          : modelCosts[litlyticsConfig.model].output;
+          : modelCosts[litlyticsConfig.modelConfig.model].output;
       const averageCost = _.round(
         averagePrompt * inputCost + averageCompletion * outputCost,
         3

--- a/app/components/ui/Overlay.tsx
+++ b/app/components/ui/Overlay.tsx
@@ -85,7 +85,10 @@ export function OverlayUI() {
 
   useEffect(() => {
     // show settings if key not set
-    if (!litlyticsConfig.llmKey?.length && webllm.loadProgress !== 1) {
+    if (
+      !litlyticsConfig.modelConfig.apiKey?.length &&
+      webllm.loadProgress !== 1
+    ) {
       setIsSettingsOpen(true);
     }
   }, [litlyticsConfig, webllm]);
@@ -106,8 +109,8 @@ export function OverlayUI() {
   const savePipeline = () => {
     const pipelineToSave = structuredClone(pipeline);
     // set model and provider
-    pipelineToSave.provider = litlyticsConfig.provider;
-    pipelineToSave.model = litlyticsConfig.model;
+    pipelineToSave.provider = litlyticsConfig.modelConfig.provider;
+    pipelineToSave.model = litlyticsConfig.modelConfig.model;
     // Convert the object to a JSON string
     const jsonString = JSON.stringify(pipeline, null, 2);
     // Create a Blob from the JSON string
@@ -145,9 +148,12 @@ export function OverlayUI() {
 
   const closeSettings = () => {
     // disallow closing if no key set
-    if (!litlyticsConfig.llmKey?.length && webllm.loadProgress !== 1) {
+    if (
+      !litlyticsConfig.modelConfig.apiKey?.length &&
+      webllm.loadProgress !== 1
+    )
       return;
-    }
+
     setIsSettingsOpen(false);
   };
 
@@ -289,7 +295,8 @@ export function OverlayUI() {
         open={isSettingsOpen}
         onClose={closeSettings}
         canClose={
-          Boolean(litlyticsConfig.llmKey?.length) || webllm.loadProgress === 1
+          Boolean(litlyticsConfig.modelConfig.apiKey?.length) ||
+          webllm.loadProgress === 1
         }
         topClassName="z-20"
       >

--- a/app/components/ui/ProviderKeys.tsx
+++ b/app/components/ui/ProviderKeys.tsx
@@ -1,20 +1,30 @@
 import { LLMProvider } from '@/src/llm/types';
 
-const providerNames: Record<LLMProvider, string> = {
+const providerNames: Record<
+  LLMProvider & Exclude<LLMProvider, 'local'>,
+  string
+> = {
   anthropic: 'Anthropic',
   gemini: 'Gemini',
   openai: 'OpenAI',
   ollama: 'Ollama',
 };
 
-const providerGuides: Record<LLMProvider, string> = {
+const providerGuides: Record<
+  LLMProvider & Exclude<LLMProvider, 'local'>,
+  string
+> = {
   anthropic: 'https://docs.anthropic.com/en/api/getting-started',
   gemini: 'https://ai.google.dev/gemini-api/docs/api-key',
   openai: 'https://platform.openai.com/docs/quickstart',
   ollama: '',
 };
 
-export function ProviderKeysHint({ provider }: { provider: LLMProvider }) {
+export function ProviderKeysHint({
+  provider,
+}: {
+  provider: LLMProvider & Exclude<LLMProvider, 'local'>;
+}) {
   return (
     <div className="mt-3 py-1 text-sm">
       Don&apos;t have API key?{' '}

--- a/app/components/ui/Recommended.tsx
+++ b/app/components/ui/Recommended.tsx
@@ -1,15 +1,14 @@
-import { LLMProviders } from '@/src/litlytics';
-import { LLMModel } from '@/src/llm/types';
+import { LLMModel, LLMProvider } from '@/src/llm/types';
 import { Popover, PopoverButton, PopoverPanel } from '@headlessui/react';
 import { QuestionMarkCircleIcon } from '@heroicons/react/24/solid';
 import { Badge } from '../catalyst/badge';
 
-export const recommendedForProvider: Record<LLMProviders, LLMModel> = {
+export const recommendedForProvider: Record<LLMProvider, LLMModel> = {
   anthropic: 'claude-3-5-sonnet-20240620',
   gemini: 'gemini-1.5-flash-latest',
   local: 'Llama-3.2-3B-Instruct-q4f16_1-MLC',
   openai: 'gpt-4o-mini',
-  ollama: '',
+  ollama: 'llama3.2',
 };
 
 export function Recommended() {

--- a/app/components/ui/UI.tsx
+++ b/app/components/ui/UI.tsx
@@ -21,12 +21,7 @@ function ClientOnly({ children }: { children: React.ReactNode }) {
   const [hasMounted, setHasMounted] = useState(false);
 
   useEffect(() => {
-    const newLL = new LitLytics({
-      provider: config.provider,
-      model: config.model,
-      key: config.llmKey,
-      engine: webllm.engine,
-    });
+    const newLL = new LitLytics(config);
     setLitlytics(newLL);
   }, [config, webllm, setLitlytics]);
 

--- a/app/routes/api.execute.tsx
+++ b/app/routes/api.execute.tsx
@@ -1,23 +1,21 @@
 import { LitLytics } from '@/src/litlytics';
-import { LLMModel, LLMProvider } from '@/src/llm/types';
+import { ModelConfig } from '@/src/llm/types';
 import { Pipeline } from '@/src/pipeline/Pipeline';
 import type { ActionFunctionArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
 
 interface ExecuteRequest {
-  provider?: LLMProvider;
-  model?: LLMModel;
-  key?: string;
+  modelConfig: ModelConfig;
   pipeline?: Pipeline;
 }
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   const body = (await request.json()) as ExecuteRequest;
-  const { provider, model, key, pipeline } = body;
-  if (!provider?.length || !model?.length) {
+  const { modelConfig, pipeline } = body;
+  if (!modelConfig.provider?.length || !modelConfig.model?.length) {
     throw new Error('Provider and model must not be empty!');
   }
-  if (!key?.length) {
+  if (!modelConfig.apiKey?.length) {
     throw new Error('API key must not be empty!');
   }
   if (!pipeline) {
@@ -25,9 +23,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   }
   // create new litlytics instance
   const litlytics = new LitLytics({
-    provider,
-    model,
-    key,
+    modelConfig,
   });
   const newPipeline = await litlytics.runPipeline(pipeline, () => {});
   return json(newPipeline);

--- a/app/store/store.ts
+++ b/app/store/store.ts
@@ -1,5 +1,5 @@
 import { LitLytics } from '@/src/litlytics';
-import { LLMModel, LLMProvider } from '@/src/llm/types';
+import { ModelConfig } from '@/src/llm/types';
 import { Pipeline, PipelineStatus } from '@/src/pipeline/Pipeline';
 import { MLCEngine } from '@mlc-ai/web-llm';
 import { atom } from 'jotai';
@@ -39,24 +39,26 @@ export const emptyPipeline: Pipeline = {
 };
 
 export const litlyticsConfigStore = atomWithStorage<{
-  provider: LLMProvider | 'local';
-  model: LLMModel;
-  llmKey: string;
+  modelConfig: ModelConfig;
 }>(
   'litltyics.config',
   {
-    provider: 'openai',
-    model: 'gpt-4o-mini',
-    llmKey: '',
+    modelConfig: {
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      apiKey: '',
+    },
   },
   undefined,
   { getOnInit: true }
 );
 export const litlyticsStore = atom<LitLytics>(
   new LitLytics({
-    provider: 'openai',
-    model: 'gpt-4o-mini',
-    key: '',
+    modelConfig: {
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      apiKey: '',
+    },
   })
 );
 

--- a/src/engine/runPrompt.ts
+++ b/src/engine/runPrompt.ts
@@ -1,58 +1,37 @@
-import { MLCEngine } from '@mlc-ai/web-llm';
 import { CoreMessage, CoreTool } from 'ai';
-import type { LLMProviders } from '../litlytics';
 import { executeOnLLM } from '../llm/llm';
-import { LLMModel, LLMProvider, LLMRequest } from '../llm/types';
+import { ModelConfig } from '../llm/types';
 import { runWithWebLLM } from '../webllm/webllm.client';
 
 export interface RunPromptFromMessagesArgs {
-  provider: LLMProviders;
-  key: string;
-  model: LLMModel;
-  engine?: MLCEngine;
   messages: CoreMessage[];
+  modelConfig: ModelConfig;
   args?: Record<string, CoreTool>;
 }
 export const runPromptFromMessages = async ({
-  provider,
-  key,
-  model,
-  engine,
   messages,
+  modelConfig,
   args,
 }: RunPromptFromMessagesArgs) => {
   // execute locally
-  if (provider === 'local') {
-    return runWithWebLLM({ engine, messages, args });
-  }
+  if (modelConfig.provider === 'local')
+    return runWithWebLLM({ engine: modelConfig.engine, messages, args });
 
-  const req: LLMRequest = {
-    provider: provider as LLMProvider,
-    key,
-    model,
+  return await executeOnLLM({
     messages,
-    modelArgs: {
-      ...(args ?? {}),
-    },
-  };
-  const res = await executeOnLLM(req);
-  return res;
+    modelConfig,
+    modelArgs: args ?? {},
+  });
 };
 
 export interface RunPromptArgs {
-  provider: LLMProviders;
-  key: string;
-  model: LLMModel;
-  engine?: MLCEngine;
+  modelConfig: ModelConfig;
   system: string;
   user: string;
   args?: Record<string, CoreTool>;
 }
 export const runPrompt = async ({
-  provider,
-  key,
-  model,
-  engine,
+  modelConfig,
   system,
   user,
   args,
@@ -65,10 +44,7 @@ export const runPrompt = async ({
   // return runWithWebLLM({ messages, args });
   // run on LLM
   return runPromptFromMessages({
-    provider,
-    key,
-    model,
-    engine,
+    modelConfig,
     messages,
     args,
   });

--- a/src/engine/step/runLLMStep.ts
+++ b/src/engine/step/runLLMStep.ts
@@ -81,10 +81,15 @@ export async function runLLMStep({
   const startTime = performance.now();
   const res = await litlytics.runPrompt({ system, user });
   const endTime = performance.now();
+
+  if (res instanceof Error) throw res;
+
+  // FIXME: shouldn't this caching check be done before the LLM call?
   // replace existing result if present
   const existingResult = doc?.processingResults.find(
     (r) => r.stepId === step.id
   );
+
   if (existingResult) {
     existingResult.result = res.result!;
     existingResult.usage = res.usage;

--- a/src/litlytics.ts
+++ b/src/litlytics.ts
@@ -1,4 +1,3 @@
-import { MLCEngine } from '@mlc-ai/web-llm';
 import { runPipeline } from './engine/runPipeline';
 import {
   runPrompt,
@@ -9,7 +8,7 @@ import {
 import { runStep, RunStepArgs } from './engine/runStep';
 import { runLLMStep, RunLLMStepArgs } from './engine/step/runLLMStep';
 import { testPipelineStep } from './engine/testStep';
-import { LLMModel, LLMProvider } from './llm/types';
+import { ModelConfig } from './llm/types';
 import { pipelineFromText } from './pipeline/fromText';
 import { generatePipeline } from './pipeline/generate';
 import { Pipeline, PipelineStatus } from './pipeline/Pipeline';
@@ -19,29 +18,11 @@ import { generateStep, GenerateStepArgs } from './step/generate';
 import { refineStep } from './step/refine';
 import { ProcessingStep } from './step/Step';
 
-export type LLMProviders = LLMProvider | 'local';
-
 export class LitLytics {
-  provider?: LLMProviders;
-  model?: LLMModel;
-  #llmKey?: string;
-  engine?: MLCEngine;
+  modelConfig: ModelConfig;
 
-  constructor({
-    provider,
-    model,
-    key,
-    engine,
-  }: {
-    provider: LLMProviders;
-    model: LLMModel;
-    key: string;
-    engine?: MLCEngine;
-  }) {
-    this.provider = provider;
-    this.model = model;
-    this.#llmKey = key;
-    this.engine = engine;
+  constructor({ modelConfig }: { modelConfig: ModelConfig }) {
+    this.modelConfig = modelConfig;
   }
 
   /**
@@ -52,19 +33,8 @@ export class LitLytics {
     messages,
     args,
   }: Pick<RunPromptFromMessagesArgs, 'messages' | 'args'>) {
-    if (
-      !this.provider?.length ||
-      !this.model?.length ||
-      (!this.#llmKey?.length && this.provider !== 'local')
-    ) {
-      throw new Error('No provider, model or key set!');
-    }
-
     return await runPromptFromMessages({
-      provider: this.provider,
-      key: this.#llmKey ?? 'local',
-      model: this.model,
-      engine: this.engine,
+      modelConfig: this.modelConfig,
       messages,
       args,
     });
@@ -75,19 +45,8 @@ export class LitLytics {
     user,
     args,
   }: Pick<RunPromptArgs, 'system' | 'user' | 'args'>) {
-    if (
-      !this.provider?.length ||
-      !this.model?.length ||
-      (!this.#llmKey?.length && this.provider !== 'local')
-    ) {
-      throw new Error('No provider, model or key set!');
-    }
-
     return await runPrompt({
-      provider: this.provider,
-      key: this.#llmKey ?? 'local',
-      model: this.model,
-      engine: this.engine,
+      modelConfig: this.modelConfig,
       system,
       user,
       args,

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -1,3 +1,4 @@
+import { MLCEngine } from '@mlc-ai/web-llm';
 import { CoreMessage, CoreTool } from 'ai';
 
 export const LLMProvidersList = [
@@ -5,7 +6,9 @@ export const LLMProvidersList = [
   'anthropic',
   'gemini',
   'ollama',
+  'local',
 ] as const;
+
 export type LLMProvider = (typeof LLMProvidersList)[number];
 
 export const LLMModelsList = {
@@ -40,10 +43,15 @@ export const LLMModelsList = {
 export type LLMModel =
   (typeof LLMModelsList)[keyof typeof LLMModelsList][number];
 
-export interface LLMRequest {
+export interface ModelConfig {
   provider: LLMProvider;
-  key: string;
   model: LLMModel;
+  apiKey?: string;
+  baseURL?: string;
+  engine?: MLCEngine;
+}
+export interface LLMRequest {
   messages: CoreMessage[];
+  modelConfig: ModelConfig;
   modelArgs?: Record<string, CoreTool>;
 }

--- a/src/pipeline/fromText.ts
+++ b/src/pipeline/fromText.ts
@@ -30,6 +30,10 @@ export async function pipelineFromText(
       system: systemToJSON,
       user: step,
     });
+
+    // TODO: handle error
+    if (stepRes instanceof Error) throw stepRes;
+
     const stepJSON = parseLLMJSON(stepRes.result!) as ProcessingStep;
     // generate id manually if LLM didn't do it for us (mostly happens with smaller LLMs)
     const id = stepJSON.id.length > 0 ? stepJSON.id : `step_${currentStep}`;

--- a/src/pipeline/generate.ts
+++ b/src/pipeline/generate.ts
@@ -15,6 +15,9 @@ export const generatePipeline = async ({
 
   // generate plan from LLM
   const plan = await litlytics.runPrompt({ system, user: description });
+  // TODO: handle error
+  if (plan instanceof Error) throw plan;
+
   const plannedSteps = plan.result
     ? parseThinkingOutputResult(plan.result)
     : plan.result;

--- a/src/pipeline/refine.ts
+++ b/src/pipeline/refine.ts
@@ -26,6 +26,9 @@ export const refinePipeline = async ({
 
   // generate plan from LLM
   const plan = await litlytics.runPromptFromMessages({ messages });
+  // TODO: handle error
+  if (plan instanceof Error) throw plan;
+
   const result = plan.result
     ? parseThinkingOutputResult(plan.result)
     : plan.result;

--- a/src/step/explain.ts
+++ b/src/step/explain.ts
@@ -15,9 +15,9 @@ export const generateCodeExplain = async ({
 
   // generate plan from LLM
   const step = await litlytics.runPrompt({ system, user: code });
-  if (!step.result) {
-    throw new Error('Error generating explanation!');
-  }
+  // TODO: handle error
+  if (step instanceof Error) throw step;
+  if (!step.result) throw new Error('Error generating explanation!');
 
   const result = parseThinkingOutputResult(step.result);
   return result;

--- a/src/step/generate.ts
+++ b/src/step/generate.ts
@@ -35,6 +35,8 @@ Step input: ${input}`;
 
   // generate plan from LLM
   const step = await litlytics.runPrompt({ system, user });
+  // TODO: handle error
+  if (step instanceof Error) throw step;
 
   const outputResult = parseThinkingOutputResult(step.result);
   const result = cleanResult(outputResult, type);

--- a/src/step/refine.ts
+++ b/src/step/refine.ts
@@ -40,6 +40,9 @@ Step input: ${step.input}`;
 
   // generate plan from LLM
   const plan = await litlytics.runPromptFromMessages({ messages });
+  // TODO: handle error
+  if (plan instanceof Error) throw plan;
+
   const res = plan.result
     ? parseThinkingOutputResult(plan.result)
     : plan.result;


### PR DESCRIPTION
This is a chunky one.
The gist is that the `ModelConfig` interface now groups and uniforms all model-related configs.

The change has been propagated throughout the whole project. This implies breaking change of the `/api/execute` body. Since the early stages of the project, it might be deemed acceptable.

Some minor changes, stylistic refactors and readability improvements have also been applied.